### PR TITLE
Symlink libshaderc.so.1 for pcsx2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,6 +280,9 @@ RUN \
   ln -s \
     /opt/duckstation/AppRun \
     /usr/bin/duckstation-qt && \
+  ln -s \
+    /opt/duckstation/usr/bin/libshaderc_shared.so \
+    /usr/lib/x86_64-linux-gnu/libshaderc.so.1 && \
   echo "**** install flycast ****" && \
   FLYCAST_URL=$(curl -sX GET "https://api.github.com/repos/flyinghead/flycast/releases/latest" \
     | awk -F '(": "|")' '/browser.*.AppImage/ {print $3}') && \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-webstation/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Symlinks `libshaderc.so.1` to the copy that ships with duckstation, in the duckstation install block.

## Benefits of this PR and context:

pcsx2 dlopens `libshaderc.so.1` and there is no copy in the image, so it fails to start:

```
Failed to load shaderc: Loading libshaderc.so.1 failed: libshaderc.so.1: cannot open shared object file: No such file or directory
Failed to compile utility pipelines
Failed to create GS device
Startup Error: Failed to initialize GS
```

It only bites on a cold shader cache, which is why it is easy to miss. With a warm `/config/.config/PCSX2/cache` pcsx2 runs fine without the library.

## How Has This Been Tested?

Made the same symlink by hand in a running container off the romm branch, then ran pcsx2 with `/config/.config/PCSX2/cache` cleared. Without it pcsx2 dies with the error above, with it the game boots. Not yet tested as a rebuilt image.

## Source / References:

n/a
